### PR TITLE
fix: node install layer not cleaned up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
-FROM ruby:2.3
+FROM ruby:2.6
 
 RUN apt-get update --yes ;\
     apt-get --yes install apt-transport-https ;\
     apt-get clean ;\
     rm -rf /var/lib/apt/lists/*
 
-# Install node
+# Install node and yarn
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - ;\
-    apt-get install -y nodejs
-
-# Install yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - ;\
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - ;\
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list ;\
-    apt-get update --yes ;\
-    apt-get install --yes yarn ;\
+    apt-get update -y ;\
+    apt-get install -y nodejs yarn ;\
     apt-get clean ;\
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- node installing layer was not cleaning up afterwards
- since yarn without node is kind of pointless, combine the node and yarn layer in one